### PR TITLE
Small fix to detect msys environment

### DIFF
--- a/compiler/BTW/cygwin.vim
+++ b/compiler/BTW/cygwin.vim
@@ -55,7 +55,7 @@ set cpo&vim
 " Avoid global reinclusion }}}1
 "------------------------------------------------------------------------
 " Check we are using cygwin                 {{{1
-if !has('win32') 
+if !(has('win32') || has('win32unix'))
       \ || !( ($TERM=='cygwin') || ($OSTYPE=='cygwin') || executable('cygpath'))
   echoerr "Cygwin not detected..."
   finish


### PR DESCRIPTION
Looks promising,

This doesn't solve all the problems,
ie the pattern match doesn't work when the output comes from CMake+Ninja (have not tested make),
Ninja looks like 
`101 C:\work\file.cpp:234: errormessage`

And I haven't tested cmake+MSVC yet.

I see there are a lot more patches on the 'project' branch, but that has a lot of errors when I tried to use it.

Note that I'm using with vim, importing with
```
Plug 'LucHermitte/lh-vim-lib'
Plug 'LucHermitte/vim-build-tools-wrapper'
Plug 'powerman/vim-plugin-AnsiEsc'
```

But as you suggest in stackoverflow, I only really need that vim cygwin bit.